### PR TITLE
Delete checking on the line where the cursor is at

### DIFF
--- a/src/yaml-parser.ts
+++ b/src/yaml-parser.ts
@@ -3,7 +3,6 @@ const FIND_KEY_REGEX = /^\s*[\-|\s]?([\w|\s|\~\(|\)]*):.*/;
 
 import {
   isKey,
-  isCommentLine,
   textIndentations,
   isUnnecessaryLine,
   findLineOfClosestKey,
@@ -14,9 +13,6 @@ function parseYaml(editor) {
 
   const { document, selection } = editor;
   const selectedLine = document.lineAt(selection.active);
-  if (selectedLine.isEmptyOrWhitespace || isCommentLine(selectedLine.text)) {
-    return false;
-  }
 
   const range = new Range(0, 0, selection.end.line, selectedLine.text.length);
   const replaced  = document.getText(range).replace(/(\rn|\n|\r)/g, '\n')


### PR DESCRIPTION
Thank you for a useful extension! This is a pull request to resolve the issue I'm experiencing.

When I try to execute stREST call when I put the cursor on a empty line (e.g. the last line on a file), It produces an error saying "Could not calculate YAML path". And it was due to the lines I removed in this PR. Since empty or commented lines are filtered below in the same function, I think these lines are useless.